### PR TITLE
Fix transport selection and search template

### DIFF
--- a/active/scripts/prxy.mjs
+++ b/active/scripts/prxy.mjs
@@ -29,12 +29,15 @@ export async function getUV(input) {
   let url = search(input, "https://html.duckduckgo.com/html?t=h_&q=%s");
 
   let wispUrl = "wss://gointospace.app/wisp/";
-  if ((await connection.getTransport()) !== "/active/prxy/epoxy/index.mjs") {
+
+  // Attempt to use the epoxy transport first and fall back to libcurl if it
+  // fails. Previously the logic always set the transport to libcurl due to a
+  // misplaced path check, preventing epoxy from ever being used.
+  try {
     await connection.setTransport("/active/prxy/epoxy/index.mjs", [
       { wisp: wispUrl },
     ]);
-  }
-  if ((await connection.getTransport()) !== "/activeprxy/libcurl/libcurl.mjs") {
+  } catch (err) {
     await connection.setTransport("/active/prxy/libcurl/libcurl.mjs", [
       { wisp: wispUrl },
     ]);

--- a/active/scripts/tabs.mjs
+++ b/active/scripts/tabs.mjs
@@ -221,7 +221,9 @@ async function addTab(link) {
   tab.title = decodeURIComponent(
     __uv$config.decodeUrl(url.substring(url.lastIndexOf("/") + 1))
   ).replace(/^https?:\/\//, "");
-  tab.url = search(link);
+  // Ensure search() always receives a template so unexpected input doesn't
+  // throw an error when performing a search query.
+  tab.url = search(link, "https://html.duckduckgo.com/html?t=h_&q=%s");
   tab.proxiedUrl = url;
   tab.icon = null;
   tab.view = tabFrame(tab);
@@ -257,7 +259,7 @@ if (urlParams.has("inject")) {
   const injection = urlParams.get("inject");
 
   setTimeout(() => {
-    addTab(injection)
-    focusTab()
+    addTab(injection);
+    focusTab();
   }, 100);
 }


### PR DESCRIPTION
## Summary
- Fix proxy transport selection by falling back to libcurl only if epoxy fails
- Ensure tab search always uses a search template and add missing semicolons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1b037d5883298047ce68dcdc2720